### PR TITLE
Add merge tag support

### DIFF
--- a/src/Form/MergeTags.php
+++ b/src/Form/MergeTags.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace GFPDF\Plugins\WPML\Form;
+
+use GFPDF\Helper\Helper_Trait_Logger;
+use GFPDF\Plugins\WPML\Wpml\WpmlInterface;
+
+/**
+ * Save the WPML Language Code with Gravity Forms Entry
+ *
+ * @package     Gravity PDF for WPML
+ * @copyright   Copyright (c) 2018, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ * @since       0.1
+ */
+
+/* Exit if accessed directly */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/*
+	This file is part of Gravity PDF for WPML.
+
+	Copyright (c) 2018, Blue Liquid Designs
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program; if not, write to the Free Software
+	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+*/
+
+/**
+ * Class MergeTags
+ *
+ * @package GFPDF\Plugins\WPML\Form
+ */
+class MergeTags {
+
+	/**
+	 * @var WpmlInterface
+	 *
+	 * @since 0.1
+	 */
+	protected $wpml;
+
+	/**
+	 * @var GravityFormsInterface
+	 *
+	 * @since 0.1
+	 */
+	protected $gf;
+
+	/**
+	 * StoreWpmlLanguage constructor.
+	 *
+	 * @param WpmlInterface         $wpml
+	 * @param GravityFormsInterface $gf
+	 *
+	 * @since 0.1
+	 */
+	public function __construct( WpmlInterface $wpml, GravityFormsInterface $gf ) {
+		$this->wpml = $wpml;
+		$this->gf   = $gf;
+	}
+
+	/**
+	 * @since 0.1
+	 */
+	public function init() {
+		$this->add_filters();
+	}
+
+	/**
+	 * @since 0.1
+	 */
+	public function add_filters() {
+		add_filter( 'gform_custom_merge_tags', [ $this, 'add' ], 10 );
+		add_filter( 'gform_replace_merge_tags', [ $this, 'process' ], 10, 3 );
+	}
+
+	/**
+	 * Add custom merge tags that include the WPML Language Code / Language
+	 *
+	 * @param array $tags
+	 *
+	 * @return array
+	 *
+	 * @since 0.1
+	 */
+	public function add( $tags ) {
+		$tags [] = [
+			'tag'   => '{wpml:language_code}',
+			'label' => esc_html__( 'Entry Language Code', 'gravity-pdf-for-wpml' ),
+		];
+
+		$tags [] = [
+			'tag'   => '{wpml:language_name}',
+			'label' => esc_html__( 'Entry Language Name', 'gravity-pdf-for-wpml' ),
+		];
+
+		$tags [] = [
+			'tag'   => '{wpml:translated_language_name}',
+			'label' => esc_html__( 'Entry Translated Language Name', 'gravity-pdf-for-wpml' ),
+		];
+
+		return $tags;
+	}
+
+	/**
+	 * Translate the WPML Merge Tags to their appropriate value
+	 *
+	 * @param string $text  The text to translate
+	 * @param array  $form  The Gravity Forms object
+	 * @param array  $entry The Gravity Forms Entry object
+	 *
+	 * @return string
+	 *
+	 * @since 0.1
+	 */
+	public function process( $text, $form, $entry ) {
+
+		/* Exit early if no applicable tags found */
+		if ( strpos( $text, '{wpml:' ) === false ) {
+			return $text;
+		}
+
+		$languages = $this->wpml->get_site_languages();
+
+		$language_code            = $this->gf->get_entry_language_code( $entry['id'] );
+		$language_name            = isset( $languages[ $language_code ] ) ? $languages[ $language_code ]['native_name'] : '';
+		$translated_language_name = isset( $languages[ $language_code ] ) ? $languages[ $language_code ]['translated_name'] : '';
+
+		$text = str_replace( '{wpml:language_code}', $language_code, $text );
+		$text = str_replace( '{wpml:language_name}', $language_name, $text );
+		$text = str_replace( '{wpml:translated_language_name}', $translated_language_name, $text );
+
+		return $text;
+	}
+
+}

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -10,6 +10,7 @@ use GFPDF\Helper\Helper_Notices;
 
 use GFPDF\Plugins\WPML\Form\EditWpmlLanguageCode;
 use GFPDF\Plugins\WPML\Form\GravityForms;
+use GFPDF\Plugins\WPML\Form\MergeTags;
 use GFPDF\Plugins\WPML\Form\StoreWpmlLanguage;
 use GFPDF\Plugins\WPML\Options\GlobalSettings;
 use GFPDF\Plugins\WPML\Pdf\DownloadLinks;
@@ -87,6 +88,7 @@ class Bootstrap extends Helper_Abstract_Addon {
 				new EditWpmlLanguageCode( $wpml, $gf ),
 				new FormData( $gf ),
 				new GlobalSettings(),
+				new MergeTags( $wpml, $gf ),
 			]
 		);
 

--- a/tests/phpunit/unit-tests/Form/TestMergeTags.php
+++ b/tests/phpunit/unit-tests/Form/TestMergeTags.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace GFPDF\Plugins\WPML\Form;
+
+/**
+ * @package     Gravity PDF for WPML
+ * @copyright   Copyright (c) 2018, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ * @since       0.1
+ */
+
+/* Exit if accessed directly */
+use GFPDF\Plugins\WPML\Wpml\WpmlTesting;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/*
+	This file is part of Gravity PDF for WPML.
+
+	Copyright (c) 2018, Blue Liquid Designs
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program; if not, write to the Free Software
+	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+*/
+
+/**
+ * Class TestMergeTags
+ *
+ * @group   form
+ *
+ * @package GFPDF\Plugins\WPML\Form
+ */
+class TestMergeTags extends \WP_UnitTestCase {
+
+	/**
+	 * @var MergeTags
+	 *
+	 * @since 0.1
+	 */
+	protected $class;
+
+	/**
+	 * @var GravityForms
+	 *
+	 * @since 0.1
+	 */
+	protected $gf;
+
+	/**
+	 * @var WpmlTesting
+	 *
+	 * @since 0.1
+	 */
+	protected $wpml;
+
+	/**
+	 * @since 0.1
+	 */
+	public function setUp() {
+
+		parent::setUp();
+
+		$this->gf   = new GravityForms();
+		$this->wpml = new WpmlTesting();
+
+		$this->class = new MergeTags( $this->wpml, $this->gf );
+		$this->class->init();
+	}
+
+	/**
+	 * @since 0.1
+	 */
+	protected function create_form() {
+		return \GFAPI::add_form( json_decode( file_get_contents( __DIR__ . '/../../json/sample-wpml-form.json' ), true ) );
+	}
+
+	/**
+	 * @since 0.1
+	 */
+	public function test_add_mergetags() {
+		$tags = $this->class->add( [] );
+
+		$this->assertEquals( '{wpml:language_code}', $tags[0]['tag'] );
+		$this->assertEquals( '{wpml:language_name}', $tags[1]['tag'] );
+		$this->assertEquals( '{wpml:translated_language_name}', $tags[2]['tag'] );
+	}
+
+	/**
+	 * @since 0.1
+	 */
+	public function test_process_mergetags() {
+		$form_id  = $this->create_form();
+		$entry_id = \GFAPI::add_entry(
+			[
+				'form_id' => $form_id,
+				13        => 'My Field Data',
+			]
+		);
+
+		$this->gf->save_entry_language_code( $entry_id, 'fr' );
+
+		$this->assertEquals( 'fr', $this->class->process( '{wpml:language_code}', [], [ 'id' => $entry_id ] ) );
+		$this->assertEquals( 'Français', $this->class->process( '{wpml:language_name}', [], [ 'id' => $entry_id ] ) );
+		$this->assertEquals( 'French', $this->class->process( '{wpml:translated_language_name}', [], [ 'id' => $entry_id ] ) );
+	}
+}


### PR DESCRIPTION
Adds the tags `{wpml:language_code}`, `{wpml:language_name}` and `{wpml:translated_language_name}`. 

Resolves #2 