### PR TITLE
Refractor how PDF translations are done

### DIFF
--- a/src/Form/MergeTags.php
+++ b/src/Form/MergeTags.php
@@ -99,18 +99,8 @@ class MergeTags {
 	 */
 	public function add( $tags ) {
 		$tags [] = [
-			'tag'   => '{wpml:language_code}',
-			'label' => esc_html__( 'Entry Language Code', 'gravity-pdf-for-wpml' ),
-		];
-
-		$tags [] = [
-			'tag'   => '{wpml:language_name}',
-			'label' => esc_html__( 'Entry Language Name', 'gravity-pdf-for-wpml' ),
-		];
-
-		$tags [] = [
-			'tag'   => '{wpml:translated_language_name}',
-			'label' => esc_html__( 'Entry Translated Language Name', 'gravity-pdf-for-wpml' ),
+			'tag'   => '{wpml:current_language_code}',
+			'label' => esc_html__( 'Current Language Code', 'gravity-pdf-for-wpml' ),
 		];
 
 		return $tags;
@@ -134,15 +124,8 @@ class MergeTags {
 			return $text;
 		}
 
-		$languages = $this->wpml->get_site_languages();
-
-		$language_code            = $this->gf->get_entry_language_code( $entry['id'] );
-		$language_name            = isset( $languages[ $language_code ] ) ? $languages[ $language_code ]['native_name'] : '';
-		$translated_language_name = isset( $languages[ $language_code ] ) ? $languages[ $language_code ]['translated_name'] : '';
-
-		$text = str_replace( '{wpml:language_code}', $language_code, $text );
-		$text = str_replace( '{wpml:language_name}', $language_name, $text );
-		$text = str_replace( '{wpml:translated_language_name}', $translated_language_name, $text );
+		$text = str_replace( '{wpml:current_language_code}', $this->wpml->get_current_site_language(), $text );
+		$text = str_replace( '{wpml:entry_language_code}', $this->gf->get_entry_language_code( $entry['id'] ), $text );
 
 		return $text;
 	}

--- a/src/Options/GlobalSettings.php
+++ b/src/Options/GlobalSettings.php
@@ -91,7 +91,7 @@ class GlobalSettings {
 					'On'  => esc_html__( 'On', 'gravity-pdf-for-wpml' ),
 					'Off' => esc_html__( 'Off', 'gravity-pdf-for-wpml' ),
 				],
-				'std'     => 'On',
+				'std'     => 'Off',
 				'tooltip' => '<h6>' . esc_html__( 'Only Translate User Notification PDFs', 'gravity-pdf-for-wpml' ) . '</h6>' . sprintf( esc_html__( 'When on, only Notifications that have the %1$sSend To%2$s setting set to %1$sSelect a Field%2$s will have PDFs translated. When off, PDFs attached to all Notifications will be translated.', 'gravity-pdf-for-wpml' ), '<code>', '</code>' ),
 			],
 

--- a/src/Wpml/Wpml.php
+++ b/src/Wpml/Wpml.php
@@ -203,7 +203,6 @@ class Wpml implements WpmlInterface {
 	public function get_translated_gravityform( $form, $language_code ) {
 		$this->set_site_language( $language_code );
 		$translated_form = apply_filters( 'gform_pre_render', $form, false, [] );
-		$this->restore_site_language();
 
 		return $translated_form;
 	}
@@ -242,7 +241,7 @@ class Wpml implements WpmlInterface {
 		 * Prepare a single SQL statement to get the translation status from WPML
 		 *
 		 * Disabled SQL code-sniff check because we're dynamically populating the placeholders
-		 * phpcs:disable WordPress.WP.PreparedSQL.NotPrepared
+		 * phpcs:disable WordPress.DB.PreparedSQL.NotPrepared
 		 */
 		$placeholder = implode( ', ', array_fill( 0, count( $available_translations ), '%d' ) );
 		$sql         = "SELECT translation_id, status FROM {$wpdb->prefix}icl_translation_status WHERE translation_id IN ($placeholder)";

--- a/tests/phpunit/unit-tests/Form/TestGravityForms.php
+++ b/tests/phpunit/unit-tests/Form/TestGravityForms.php
@@ -148,11 +148,9 @@ class TestGravityForms extends \WP_UnitTestCase {
 
 		$this->assertEquals( 'Sample WPML Form', $form_meta['title'] );
 
-		add_filter(
-			'gform_form_post_get_meta', function( $form ) {
-				return 'Fresh copy';
-			}
-		);
+		add_filter( 'gform_form_post_get_meta', function( $form ) {
+			return 'Fresh copy';
+		} );
 
 		/* Verify pulling from the cache */
 		$form_meta = \GFFormsModel::get_form_meta( $form_id );

--- a/tests/phpunit/unit-tests/Form/TestMergeTags.php
+++ b/tests/phpunit/unit-tests/Form/TestMergeTags.php
@@ -93,9 +93,7 @@ class TestMergeTags extends \WP_UnitTestCase {
 	public function test_add_mergetags() {
 		$tags = $this->class->add( [] );
 
-		$this->assertEquals( '{wpml:language_code}', $tags[0]['tag'] );
-		$this->assertEquals( '{wpml:language_name}', $tags[1]['tag'] );
-		$this->assertEquals( '{wpml:translated_language_name}', $tags[2]['tag'] );
+		$this->assertEquals( '{wpml:current_language_code}', $tags[0]['tag'] );
 	}
 
 	/**
@@ -110,10 +108,18 @@ class TestMergeTags extends \WP_UnitTestCase {
 			]
 		);
 
-		$this->gf->save_entry_language_code( $entry_id, 'fr' );
+		/* Test current site language tags */
+		$this->wpml->set_site_language( 'es' );
+		$this->assertEquals( 'es', $this->class->process( '{wpml:current_language_code}', [], [ 'id' => $entry_id ] ) );
 
-		$this->assertEquals( 'fr', $this->class->process( '{wpml:language_code}', [], [ 'id' => $entry_id ] ) );
-		$this->assertEquals( 'Français', $this->class->process( '{wpml:language_name}', [], [ 'id' => $entry_id ] ) );
-		$this->assertEquals( 'French', $this->class->process( '{wpml:translated_language_name}', [], [ 'id' => $entry_id ] ) );
+		$this->wpml->set_site_language( 'en' );
+		$this->assertEquals( 'en', $this->class->process( '{wpml:current_language_code}', [], [ 'id' => $entry_id ] ) );
+
+		/* Test entry language code tags */
+		$this->gf->save_entry_language_code( $entry_id, 'fr' );
+		$this->assertEquals( 'fr', $this->class->process( '{wpml:entry_language_code}', [], [ 'id' => $entry_id ] ) );
+
+		$this->gf->save_entry_language_code( $entry_id, 'es' );
+		$this->assertEquals( 'es', $this->class->process( '{wpml:entry_language_code}', [], [ 'id' => $entry_id ] ) );
 	}
 }

--- a/tests/phpunit/unit-tests/Pdf/TestTranslation.php
+++ b/tests/phpunit/unit-tests/Pdf/TestTranslation.php
@@ -102,45 +102,43 @@ class TestTranslation extends \WP_UnitTestCase {
 			]
 		);
 
+		/* Test the current site language for French */
 		$this->wpml->set_site_language( 'fr' );
-
 		$this->class->pre_pdf_view_or_download( $entry_id );
-		$this->assertEquals( 'fr', $this->class->get_language_code() );
+		$this->assertEquals( 'fr', $this->wpml->get_current_site_language() );
+		$this->assertEquals( 'view-download', $this->class->get_pdf_type() );
 
-		$this->class->reset_language_code();
-
+		$this->wpml->set_site_language( 'fr' );
 		$this->class->pre_pdf_generation( [], [ 'id' => $entry_id ] );
-		$this->assertEquals( 'fr', $this->class->get_language_code() );
+		$this->assertEquals( 'fr', $this->wpml->get_current_site_language() );
+		$this->assertEquals( 'api', $this->class->get_pdf_type() );
+
+		/* Test the current site language for Spanish */
+		$this->wpml->set_site_language( 'es' );
+		$this->class->pre_pdf_view_or_download( $entry_id );
+		$this->assertEquals( 'es', $this->wpml->get_current_site_language() );
 
 		$this->wpml->set_site_language( 'es' );
-
-		$this->class->pre_pdf_view_or_download( $entry_id );
-		$this->assertEquals( 'es', $this->class->get_language_code() );
-
-		$this->class->reset_language_code();
-
 		$this->class->pre_pdf_generation( [], [ 'id' => $entry_id ] );
-		$this->assertEquals( 'es', $this->class->get_language_code() );
+		$this->assertEquals( 'es', $this->wpml->get_current_site_language() );
+
+		/* Test that we fallback to the default site language when a language isn't found */
+		$this->wpml->set_site_language( 'hi' );
+		$this->class->pre_pdf_view_or_download( $entry_id );
+		$this->assertEquals( 'en', $this->wpml->get_current_site_language() );
 
 		$this->wpml->set_site_language( 'hi' );
-
-		$this->class->pre_pdf_view_or_download( $entry_id );
-		$this->assertEquals( 'en', $this->class->get_language_code() );
-
-		$this->class->reset_language_code();
-
 		$this->class->pre_pdf_generation( [], [ 'id' => $entry_id ] );
-		$this->assertEquals( 'en', $this->class->get_language_code() );
+		$this->assertEquals( 'en', $this->wpml->get_current_site_language() );
+
+		/* Test the default language English */
+		$this->wpml->set_site_language( 'en' );
+		$this->class->pre_pdf_view_or_download( $entry_id );
+		$this->assertEquals( 'en', $this->wpml->get_current_site_language() );
 
 		$this->wpml->set_site_language( 'en' );
-
-		$this->class->pre_pdf_view_or_download( $entry_id );
-		$this->assertEquals( 'en', $this->class->get_language_code() );
-
-		$this->class->reset_language_code();
-
 		$this->class->pre_pdf_generation( [], [ 'id' => $entry_id ] );
-		$this->assertEquals( 'en', $this->class->get_language_code() );
+		$this->assertEquals( 'en', $this->wpml->get_current_site_language() );
 	}
 
 	public function test_pre_pdf_generation_notification() {
@@ -158,20 +156,21 @@ class TestTranslation extends \WP_UnitTestCase {
 		$this->gf->save_entry_language_code( $entry_id, 'fr' );
 
 		$this->class->pre_pdf_generation_notification( $form, $entry, [], [ 'toType' => 'field' ] );
-		$this->assertEquals( 'fr', $this->class->get_language_code() );
+		$this->assertEquals( 'fr', $this->wpml->get_current_site_language() );
+		$this->assertEquals( 'notification', $this->class->get_pdf_type() );
 
 		$this->class->pre_pdf_generation_notification( $form, $entry, [], [] );
-		$this->assertEquals( 'en', $this->class->get_language_code() );
+		$this->assertEquals( 'en', $this->wpml->get_current_site_language() );
 
 		/* Disable the User Notification only option and re-test */
 		\GPDFAPI::update_plugin_option( 'wpml_user_notification', 'Off' );
 
 		$this->class->pre_pdf_generation_notification( $form, $entry, [], [] );
-		$this->assertEquals( 'fr', $this->class->get_language_code() );
+		$this->assertEquals( 'fr', $this->wpml->get_current_site_language() );
 
 		$this->gf->save_entry_language_code( $entry_id, 'hi' );
 		$this->class->pre_pdf_generation_notification( $form, $entry, [], [] );
-		$this->assertEquals( 'en', $this->class->get_language_code() );
+		$this->assertEquals( 'en', $this->wpml->get_current_site_language() );
 	}
 
 	public function test_translate_gravityform() {
@@ -183,16 +182,16 @@ class TestTranslation extends \WP_UnitTestCase {
 		$new_form = $this->class->translate_gravityform( $form );
 		$this->assertSame( $form, $new_form );
 
-		$this->class->set_language_code( 'es' );
+		$this->class->set_language_code( 'es', 'api' );
 		$new_form = $this->class->translate_gravityform( $form );
 		$this->assertEquals( 'My Form (es)', $new_form['title'] );
 	}
 
 	public function test_post_pdf_generation() {
-		$this->class->set_language_code( 'fr' );
-		$this->assertEquals( 'fr', $this->class->get_language_code() );
+		$this->class->set_language_code( 'fr', 'api' );
+		$this->assertEquals( 'fr', $this->wpml->get_current_site_language() );
 
 		$this->class->post_pdf_generation();
-		$this->assertEquals( '', $this->class->get_language_code() );
+		$this->assertEquals( 'en', $this->wpml->get_current_site_language() );
 	}
 }


### PR DESCRIPTION
This PR changes how PDFs get translated. Instead of tracking the current language internally, we're overriding WPML's current language and reseting it after the PDF is generated. 

We also added a new `{wpml:current_language_code}` to overcome caching problems due to non-unique filenames with translated PDFs. When this merge tag is used in the PDF filename, this resolves the problem when User Notifications are translated, but admin notifications are not. We also set the default User Notification option to `Off` to prevent PDF generation issues due to non-unique filenames. If users want that feature, they'll need to opt-in (and hopefully read the documentation about it). 

Trying to guess the correct language for the language name translations was too complex. We couldn't consistently produce the same language name, which means it's no good for conditional logic. Devs who want the name can write their own logic. So we've remove all merge tags except `{wpml:current_language_code}` and newly renamed `{wpml:entry_language_code}` (for power users).


